### PR TITLE
Rate limit autoreplys and blacklist certain recipients

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,10 @@ need to be set in the config file::
     autorespond=yes
     # Autorespond message, new lines must be escaped.
     autorespond_text=Dear sender,\n\nThank you for your email. This email address is no longer valid. Your message will be forwarded.
+    # Enable rate limiting
+    rate_limit_active=yes
+    # Allowed reply messages per minute
+    rate_limit=5
 
 Systemd
 *****************

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ need to be set in the config file::
     rate_limit_active=yes
     # Allowed reply messages per minute
     rate_limit=5
+    # Recipient blacklist rules, separated by semicolons
+    reply_blacklist=no-reply@*;noreply@*
 
 Systemd
 *****************

--- a/imaprelay/command.py
+++ b/imaprelay/command.py
@@ -47,6 +47,8 @@ def main():
                       config.get('relay', 'archive'),
                       config.getboolean('relay', 'autorespond'),
                       config.get('relay', 'autorespond_text'),
-                      config.get('smtp', 'address'))
+                      config.get('smtp', 'address'),
+                      config.getboolean('relay', 'rate_limit_active'),
+                      config.get('relay', 'rate_limit'))
     
     rly.loop(int(config.get('relay', 'interval')))

--- a/imaprelay/command.py
+++ b/imaprelay/command.py
@@ -49,6 +49,7 @@ def main():
                       config.get('relay', 'autorespond_text'),
                       config.get('smtp', 'address'),
                       config.getboolean('relay', 'rate_limit_active'),
-                      config.get('relay', 'rate_limit'))
+                      config.get('relay', 'rate_limit'),
+                      config.get('relay', 'reply_blacklist'))
     
     rly.loop(int(config.get('relay', 'interval')))

--- a/imaprelay/relay.py
+++ b/imaprelay/relay.py
@@ -159,7 +159,7 @@ class Relay(object):
                 if self._check_blacklist(autoreply['To']):
                     pass
                 else:
-                    break
+                    continue
                 try:
                     res = self.smtp.sendmail(autoreply['From'], autoreply['To'], autoreply.as_bytes())
                     log.debug("Sent autorespond message '{subj}' from {from_} to {to}".format(

--- a/imaprelay/relay.py
+++ b/imaprelay/relay.py
@@ -151,15 +151,15 @@ class Relay(object):
                 autoreply['From'] = self.smtp_address
                 autoreply['To'] = eml['Reply-To'] or eml['From']
                 autoreply.attach(MIMEText(self.autorespond_text.replace("\\n", "\n"), 'plain'))
-                if self.rate_limit_active:
-                    if self._check_rate_limit():
-                        pass
-                    else:
-                        break
-                if self._check_blacklist(autoreply['To']):
-                    pass
-                else:
+
+                # do not send if rate limi exceeded
+                if self.rate_limit_active and not self._check_rate_limit():
+                    break
+                
+                # do not send if blacklisted
+                if not self._check_blacklist(autoreply['To']):
                     continue
+                    
                 try:
                     res = self.smtp.sendmail(autoreply['From'], autoreply['To'], autoreply.as_bytes())
                     log.debug("Sent autorespond message '{subj}' from {from_} to {to}".format(


### PR DESCRIPTION
To avoid no-reply message avalanches I implemented a rate limiter and a regex based recipient blacklist. As I do not have this system active, yet, I only tested the logic (the ```Relay._check_*``` functions). The integration into the autoreply function and the config file integration are untested.